### PR TITLE
Fix Wi-Fi sensors not working

### DIFF
--- a/HA_Desktop_Companion/Libraries/Sensors.cs
+++ b/HA_Desktop_Companion/Libraries/Sensors.cs
@@ -66,7 +66,7 @@ namespace HA_Desktop_Companion.Libraries
                 string[] output = process.StandardOutput.ReadToEnd().ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
                 process.WaitForExit();
 
-                foreach (var item in process.StandardOutput.ReadToEnd().ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None))
+                foreach (var item in output)
                 {
                     if (item.Split(":").Count() < 2)
                         continue;


### PR DESCRIPTION
Fix for Issue #34: https://github.com/GamerClassN7/HA_Desktop_Companion/issues/34
WiFi sensors returning empty as the process output changes after the process finishes, so using the output var instead.