### PR TITLE
Search for ConsentStore under LocalMachine

### DIFF
--- a/HA_Desktop_Companion/Libraries/Sensors.cs
+++ b/HA_Desktop_Companion/Libraries/Sensors.cs
@@ -198,6 +198,32 @@ namespace HA_Desktop_Companion.Libraries
                             }
                         }
                     }
+                    // Repeat the same search now under "LocalMachine"
+                    using (var rootKey = Registry.LocalMachine.OpenSubKey(path))
+                    {
+                        if (rootKey != null)
+                        {
+                            foreach (var subKeyName in rootKey.GetSubKeyNames())
+                            {
+
+                                using (var subKey = rootKey.OpenSubKey(subKeyName))
+                                {
+                                    if (subKey.GetValueNames().Contains("LastUsedTimeStop"))
+                                    {
+
+                                        var endTime = (long)subKey.GetValue("LastUsedTimeStop");
+                                        //Debug.WriteLine(consent_category + " " + subKey.GetValue("LastUsedTimeStop"));
+
+                                        if (endTime == 0)
+                                        {
+                                            //MessageBox.Show(subKey.GetValue("LastUsedTimeStop").ToString());
+                                            return true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
             catch (Exception){}


### PR DESCRIPTION
I don't think this is the fix for #37, as that one looks like related to an exception outside the webcam sensor (which I'm still working on), but this change will support the detection when the camera is in use by another system/user other than the user running HA_Desktop_Companion application. By the way, the HASS.Agent also looks for ConsentStore in both CurrentUser and LocalMachine.