### PR TITLE
Fix websocket URL failure w/o trailing slash

### DIFF
--- a/HA/Class/HomeAssistant/HomeAssistantWS.cs
+++ b/HA/Class/HomeAssistant/HomeAssistantWS.cs
@@ -68,7 +68,7 @@ namespace HA.Class.HomeAssistant
             {
                 Logger.write("WS INITIALIZATION");
 
-                Uri wsAddress = new Uri(url + "api/websocket");
+                Uri wsAddress = new Uri(url.TrimEnd('/') + "/api/websocket");
                 var exitEvent = new ManualResetEvent(false);
                 socket.Options.KeepAliveInterval = TimeSpan.Zero;
 


### PR DESCRIPTION
I had some troubles connecting this app to my HA instance. 
API worked fine, but WS would fail. Looking into it, it seemed the URI building was handled differently for which the API is able to deal with trailing slashes and the WS part does not.

This PR takes trailing slashes on the base URL into account when trying to setup a websocket connection.